### PR TITLE
Add POST response assertions

### DIFF
--- a/cypress/e2e/api_tests.cy.js
+++ b/cypress/e2e/api_tests.cy.js
@@ -34,10 +34,12 @@ describe('Reqres API Tests', () => {
           name: 'Eve',
           job: 'QA Lead'
         }
-      }).then((response) => {
-        expect(response.status).to.eq(201);
-        expect(response.body).to.have.property('id');
-        expect(response.body).to.have.property('createdAt');
+        }).then((response) => {
+          expect(response.status).to.eq(201);
+          expect(response.body).to.have.property('id');
+          expect(response.body).to.have.property('createdAt');
+          expect(response.body.name).to.eq('Eve');
+          expect(response.body.job).to.eq('QA Lead');
+        });
       });
     });
-  });


### PR DESCRIPTION
## Summary
- verify `name` and `job` fields in POST request test

## Testing
- `npm run test:api` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402790f560832f9b68ff6bc7f89845